### PR TITLE
ENH: Use non-deprecated Markups API

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2017, 
+Copyright (c) 2017,
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/MarkupsToModel/Logic/vtkSlicerMarkupsToModelClosedSurfaceGeneration.cxx
+++ b/MarkupsToModel/Logic/vtkSlicerMarkupsToModelClosedSurfaceGeneration.cxx
@@ -40,13 +40,13 @@ vtkSlicerMarkupsToModelClosedSurfaceGeneration::~vtkSlicerMarkupsToModelClosedSu
 //------------------------------------------------------------------------------
 bool vtkSlicerMarkupsToModelClosedSurfaceGeneration::GenerateClosedSurfaceModel(vtkPoints* inputPoints, vtkPolyData* outputPolyData,
   double delaunayAlpha, bool smoothing, bool forceConvex)
-{  
+{
   if (inputPoints == NULL)
   {
     vtkGenericWarningMacro("Input points are null. No model generated.");
     return false;
   }
-  
+
   if (outputPolyData == NULL)
   {
     vtkGenericWarningMacro("Output poly data is null. No model generated.");
@@ -222,7 +222,7 @@ bool vtkSlicerMarkupsToModelClosedSurfaceGeneration::GenerateClosedSurfaceModel(
 // 2. The axes returned are based on variation of coordinates, not the range
 //    (so the return result is not necessarily intuitive, variation != length).
 // Neither of these limitations will prevent the overall logic from functioning
-// correctly, but it is worth keeping in mind, and worth changing should a need 
+// correctly, but it is worth keeping in mind, and worth changing should a need
 // arise
 void vtkSlicerMarkupsToModelClosedSurfaceGeneration::ComputeTransformMatrixFromBoundingAxes(vtkPoints* points, vtkMatrix4x4* boundingAxesToRasTransformMatrix)
 {

--- a/MarkupsToModel/Logic/vtkSlicerMarkupsToModelLogic.cxx
+++ b/MarkupsToModel/Logic/vtkSlicerMarkupsToModelLogic.cxx
@@ -677,12 +677,12 @@ void vtkSlicerMarkupsToModelLogic::MarkupsToPoints( vtkMRMLMarkupsFiducialNode* 
     return;
   }
 
-  int numberOfInputMarkups = inputMarkupsNode->GetNumberOfFiducials();
-  outputPoints->SetNumberOfPoints( numberOfInputMarkups );
+  int numberOfInputControlPoints = inputMarkupsNode->GetNumberOfControlPoints();
+  outputPoints->SetNumberOfPoints( numberOfInputControlPoints );
   double inputMarkupPoint[ 3 ] = { 0.0, 0.0, 0.0 }; // values temporary
-  for ( int i = 0; i < numberOfInputMarkups; i++ )
+  for ( int i = 0; i < numberOfInputControlPoints; i++ )
   {
-    inputMarkupsNode->GetNthFiducialPosition( i, inputMarkupPoint );
+    inputMarkupsNode->GetNthControlPointPosition( i, inputMarkupPoint );
     outputPoints->SetPoint( i, inputMarkupPoint );
   }
 }

--- a/MarkupsToModel/Logic/vtkSlicerMarkupsToModelLogic.cxx
+++ b/MarkupsToModel/Logic/vtkSlicerMarkupsToModelLogic.cxx
@@ -368,13 +368,13 @@ bool vtkSlicerMarkupsToModelLogic::UpdateOutputCurveModel( vtkMRMLMarkupsFiducia
     vtkGenericWarningMacro( "No markups. Aborting." );
     return false;
   }
-  
+
   if ( outputModelNode == NULL )
   {
     vtkGenericWarningMacro( "No model. Aborting." );
     return false;
   }
-  
+
   // extract control points
   vtkSmartPointer< vtkPoints > controlPoints = vtkSmartPointer< vtkPoints >::New();
   vtkSlicerMarkupsToModelLogic::MarkupsToPoints( markupsNode, controlPoints );
@@ -388,7 +388,7 @@ bool vtkSlicerMarkupsToModelLogic::UpdateOutputCurveModel( vtkMRMLMarkupsFiducia
   {
     return false;
   }
-  
+
   outputModelNode->SetAndObservePolyData( outputPolyData );
 
   return true;
@@ -407,7 +407,7 @@ bool vtkSlicerMarkupsToModelLogic::UpdateOutputCurveModel( vtkPoints* controlPoi
     vtkGenericWarningMacro( "No control points. Aborting." );
     return false;
   }
-  
+
   if ( outputPolyData == NULL )
   {
     vtkGenericWarningMacro( "No poly data. Aborting." );
@@ -442,7 +442,7 @@ bool vtkSlicerMarkupsToModelLogic::UpdateOutputCurveModel( vtkPoints* controlPoi
   curveGenerator->SetInputPoints( controlPoints );
   curveGenerator->SetNumberOfPointsPerInterpolatingSegment( tubeSegmentsBetweenControlPoints );
   vtkPoints* curvePoints = NULL; // temporary value
-  
+
   // special case
   if ( controlPoints->GetNumberOfPoints() == 2 )
   {
@@ -587,7 +587,7 @@ bool vtkSlicerMarkupsToModelLogic::UpdateClosedSurfaceModel(
     vtkGenericWarningMacro( "No markups. Aborting." );
     return false;
   }
-  
+
   if ( outputModelNode == NULL )
   {
     vtkGenericWarningMacro( "No model. Aborting." );
@@ -617,7 +617,7 @@ bool vtkSlicerMarkupsToModelLogic::UpdateClosedSurfaceModel(
     vtkGenericWarningMacro( "No control points. Aborting." );
     return false;
   }
-  
+
   if ( outputPolyData == NULL )
   {
     vtkGenericWarningMacro( "No poly data. Aborting." );
@@ -773,7 +773,7 @@ void vtkSlicerMarkupsToModelLogic::GenerateTubeModel( vtkPoints* pointsToConnect
 
 //------------------------------------------------------------------------------
 void vtkSlicerMarkupsToModelLogic::AssignPolyDataToOutput( vtkMRMLMarkupsToModelNode* markupsToModelModuleNode, vtkPolyData* outputPolyData )
-{  
+{
   vtkMRMLModelNode* outputModelNode = markupsToModelModuleNode->GetOutputModelNode();
   if ( outputModelNode == NULL )
   {
@@ -796,7 +796,7 @@ void vtkSlicerMarkupsToModelLogic::AssignPolyDataToOutput( vtkMRMLMarkupsToModel
 //------------------------------------------------------------------------------
 void vtkSlicerMarkupsToModelLogic::MakeLoopContinuous( vtkPoints* curvePoints )
 {
-  // Move the starting point a tiny bit and add an *extra* point to join the curve 
+  // Move the starting point a tiny bit and add an *extra* point to join the curve
   // to the new starting position.
   double point0[ 3 ];
   curvePoints->GetPoint( 0, point0 );

--- a/MarkupsToModel/Logic/vtkSlicerMarkupsToModelLogic.h
+++ b/MarkupsToModel/Logic/vtkSlicerMarkupsToModelLogic.h
@@ -65,7 +65,7 @@ public:
 
   // Updates closed surface or curve output model from markups
   void UpdateOutputModel( vtkMRMLMarkupsToModelNode* moduleNode );
-  
+
   // lower-level access to functionality for making a closed surface model
   static bool UpdateClosedSurfaceModel( vtkMRMLMarkupsFiducialNode* markupsNode, vtkMRMLModelNode* modelNode,
       bool smoothing = true, bool forceConvex = false, double delaunayAlpha = 0.0, bool cleanMarkups = true );
@@ -82,7 +82,7 @@ public:
       vtkCurveGenerator* curveGenerator = NULL,
       int polynomialFitType = vtkMRMLMarkupsToModelNode::GlobalLeastSquares, double polynomialSampleWidth = 0.5,
       int polynomialWeightType = vtkMRMLMarkupsToModelNode::Rectangular );
-  
+
   static bool UpdateOutputCurveModel( vtkPoints* controlPoints, vtkPolyData* polyData,
       int curveType = vtkMRMLMarkupsToModelNode::Linear,
       bool tubeLoop = false, double tubeRadius = 1.0, int tubeNumberOfSides = 8, int tubeSegmentsBetweenControlPoints = 5,
@@ -95,7 +95,7 @@ public:
 
   // Get the points store in a vtkMRMLMarkupsFiducialNode
   static void MarkupsToPoints( vtkMRMLMarkupsFiducialNode* markupsNode, vtkPoints* outputPoints );
-  
+
   // Get the points store in a vtkMRMLModelNode
   static void ModelToPoints( vtkMRMLModelNode* modelNode, vtkPoints* outputPoints );
 

--- a/MarkupsToModel/MRML/vtkMRMLMarkupsToModelNode.h
+++ b/MarkupsToModel/MRML/vtkMRMLMarkupsToModelNode.h
@@ -77,7 +77,7 @@ public:
     Curve,
     ModelType_Last // insert valid types above this line
   };
-  
+
   enum CurveType
   {
     Linear = 0,
@@ -111,9 +111,9 @@ public:
   };
 
   vtkTypeMacro( vtkMRMLMarkupsToModelNode, vtkMRMLNode );
-  
-  // Standard MRML node methods  
-  static vtkMRMLMarkupsToModelNode *New();  
+
+  // Standard MRML node methods
+  static vtkMRMLMarkupsToModelNode *New();
 
   virtual vtkMRMLNode* CreateNodeInstance() override;
   virtual const char* GetNodeTagName() override { return "MarkupsToModel"; };
@@ -154,7 +154,7 @@ public:
   vtkSetMacro( TubeLoop, bool );
   vtkGetMacro( KochanekEndsCopyNearestDerivatives, bool );
   vtkSetMacro( KochanekEndsCopyNearestDerivatives, bool );
-  
+
   vtkGetMacro( AutoUpdateOutput, bool );
   vtkSetMacro( AutoUpdateOutput, bool );
   vtkGetMacro( CleanMarkups, bool );
@@ -165,7 +165,7 @@ public:
   vtkSetMacro( DelaunayAlpha, double );
   vtkGetMacro( ConvexHull, bool );
   vtkSetMacro( ConvexHull, bool );
-  
+
   double GetOutputCurveLength();
   void SetOutputCurveLength( double );
 
@@ -176,7 +176,7 @@ protected:
   virtual ~vtkMRMLMarkupsToModelNode();
   vtkMRMLMarkupsToModelNode ( const vtkMRMLMarkupsToModelNode& );
   void operator=( const vtkMRMLMarkupsToModelNode& );
-  
+
 public:
 
   void SetAndObserveInputNodeID( const char* inputNodeId );
@@ -233,7 +233,7 @@ private:
   bool   TubeLoop;
   bool   KochanekEndsCopyNearestDerivatives;
   double KochanekTension;
-  double KochanekBias; 
+  double KochanekBias;
   double KochanekContinuity;
   int    PolynomialOrder;
   int    PolynomialFitType;

--- a/MarkupsToModel/qSlicerMarkupsToModelModule.cxx
+++ b/MarkupsToModel/qSlicerMarkupsToModelModule.cxx
@@ -70,7 +70,7 @@ QString qSlicerMarkupsToModelModule::title() const
 //-----------------------------------------------------------------------------
 QString qSlicerMarkupsToModelModule::helpText() const
 {
-  return "Create a model (closed surface, tube) based on points in a Markups fiducial list.";
+  return "Create a model (closed surface, tube) based on control points in a Markups Point List.";
 }
 
 //-----------------------------------------------------------------------------

--- a/MarkupsToModel/qSlicerMarkupsToModelModuleWidget.cxx
+++ b/MarkupsToModel/qSlicerMarkupsToModelModuleWidget.cxx
@@ -280,7 +280,7 @@ void qSlicerMarkupsToModelModuleWidget::onInputNodeComboBoxSelectionChanged( vtk
   if ( inputMarkupsNode != NULL )
   {
     markupsToModelModuleNode->SetAndObserveInputNodeID( inputMarkupsNode->GetID() );
-  
+
     // Observe display node so that we can make sure the module GUI always shows up-to-date information
     // (applies specifically to markups)
     inputMarkupsNode->CreateDefaultDisplayNodes();
@@ -393,7 +393,7 @@ void qSlicerMarkupsToModelModuleWidget::updateMRMLFromGUI()
     markupsToModelModuleNode->SetPointParameterType(vtkMRMLMarkupsToModelNode::MinimumSpanningTree);
   }
   markupsToModelModuleNode->SetPolynomialOrder(d->PolynomialOrderSpinBox->value());
-  
+
   markupsToModelModuleNode->SetPolynomialSampleWidth( d->PolynomialSampleWidthDoubleSpinBox->value() );
   if ( d->WeightFunctionRectangularRadioButton->isChecked() )
   {
@@ -441,7 +441,7 @@ void qSlicerMarkupsToModelModuleWidget::updateMRMLFromGUI()
 void qSlicerMarkupsToModelModuleWidget::updateGUIFromMRML()
 {
   Q_D(qSlicerMarkupsToModelModuleWidget);
-  
+
   vtkMRMLMarkupsToModelNode* markupsToModelModuleNode = vtkMRMLMarkupsToModelNode::SafeDownCast( d->ParameterNodeSelector->currentNode() );
   if (markupsToModelModuleNode == NULL)
   {
@@ -585,7 +585,7 @@ void qSlicerMarkupsToModelModuleWidget::updateGUIFromMRML()
   }
 
   // Model display options
-  vtkMRMLModelDisplayNode* modelDisplayNode = vtkMRMLModelDisplayNode::SafeDownCast( 
+  vtkMRMLModelDisplayNode* modelDisplayNode = vtkMRMLModelDisplayNode::SafeDownCast(
     this->GetOutputModelNode() ? this->GetOutputModelNode()->GetDisplayNode() : NULL );
   if ( modelDisplayNode != NULL )
   {
@@ -634,7 +634,7 @@ void qSlicerMarkupsToModelModuleWidget::updateGUIFromMRML()
 
   // Determine visibility of widgets
   bool isInputMarkups = ( vtkMRMLMarkupsFiducialNode::SafeDownCast( inputNode ) != NULL );
-  
+
   d->InputMarkupsPlaceWidget->setVisible( isInputMarkups );
   d->MarkupsTextScaleSlider->setVisible( isInputMarkups );
 
@@ -643,7 +643,7 @@ void qSlicerMarkupsToModelModuleWidget::updateGUIFromMRML()
   d->ClosedSurfaceModelGroupBox->setVisible( isClosedSurface );
 
   bool isCurve = d->ModeCurveRadioButton->isChecked();
-  
+
   d->CurveModelGroupBox->setVisible( isCurve );
 
   bool isLinearSpline = d->LinearInterpolationRadioButton->isChecked();
@@ -752,7 +752,7 @@ void qSlicerMarkupsToModelModuleWidget::UpdateOutputModel()
     qCritical("Model node changed with no module node selection");
     return;
   }
-  
+
   // set up the output model node if needed
   vtkMRMLModelNode* outputModelNode = markupsToModelModuleNode->GetOutputModelNode();
   if (outputModelNode == NULL)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Overview
 
-**Slicer Markups to Model** is an extension of [3D Slicer](https://www.slicer.org/) for creating 3D surface models. The user first specifies a series of input points (as fiducial markups), then the module creates a model from those points. Currently there are two types of surface models that can be created: closed surfaces and curves.
+**Slicer Markups to Model** is an extension of [3D Slicer](https://www.slicer.org/) for creating 3D surface models. The user first specifies a series of input control points, then the module creates a model from those points. Currently there are two types of surface models that can be created: closed surfaces and curves.
 
 ![Overview](https://raw.githubusercontent.com/SlicerIGT/SlicerMarkupsToModel/master/Screenshots/Overview.png?raw=true)
 > Example models created using SlicerMarkupsToModel. Left: Closed Surface. Right: Curves.
@@ -20,7 +20,7 @@ The **parameter node** is used to store all options settings for the module. The
 
 The two radio buttons along the top indicate whether the model should be a **closed surface** or a **curve**.
 
-The **Input Node** is used to store input points for the model. There is an option to create a new Markup Fiducials from the drop-down selector. Fiducial markups can be added or deleted using buttons beside the selector. (*Note that advanced users can also take as input a "Model" and work with points from polygonal data).
+The **Input Node** is used to store input points for the model. There is an option to create a new Markups Point List from the drop-down selector. A Markups Point List can be added or deleted using buttons beside the selector. (*Note that advanced users can also take as input a "Model" and work with points from polygonal data).
 
 The **Output Model Node** stores the model created by this module.
 
@@ -39,7 +39,7 @@ The **Display Panel** allows convenient access to change basic rendering propert
 
 - **Model Slice Intersections**: Toggle visibility in the red, yellow, and green slice views. Model Visibility (above) must also be enabled.
 
-- **Markups Text Scale**: Change the size of text beside each input markup fiducial.
+- **Markups Text Scale**: Change the size of text beside each input markup control point.
 
 # Closed Surfaces
 
@@ -71,11 +71,11 @@ Curves are models shaped like a tube that either [interpolate](https://en.wikipe
 
 - **Clean Duplicated Markups**: Remove duplicates from the input points.
 
-**Piecewise linear** curves are the simplest type of curve that can be created. A tube model is created that passes from one input point to the next in the original order specified from the fiducial list.
+**Piecewise linear** curves are the simplest type of curve that can be created. A tube model is created that passes from one input point to the next in the original order specified from the point list.
 
-**Cardinal spline** curves appear smooth. A tube model is created that passes through each input point in the order specified from the fiducial list. Between each pair of points, there will be some curvature in the model. See [Wikipedia](https://en.wikipedia.org/wiki/Cubic_Hermite_spline#Cardinal_spline) to learn more about cardinal splines.
+**Cardinal spline** curves appear smooth. A tube model is created that passes through each input point in the order specified from the point list. Between each pair of points, there will be some curvature in the model. See [Wikipedia](https://en.wikipedia.org/wiki/Cubic_Hermite_spline#Cardinal_spline) to learn more about cardinal splines.
 
-**Kochanek spline** curves appear smooth. A tube model is created that passes through each input point in the order specified from the fiducial list. Between each pair of points, there will be some curvature in the model. See [Wikipedia](https://en.wikipedia.org/wiki/Kochanek%E2%80%93Bartels_spline) to learn more about Kochanek splines.
+**Kochanek spline** curves appear smooth. A tube model is created that passes through each input point in the order specified from the point list. Between each pair of points, there will be some curvature in the model. See [Wikipedia](https://en.wikipedia.org/wiki/Kochanek%E2%80%93Bartels_spline) to learn more about Kochanek splines.
 
 - **Curve is a Loop**: Indicate if the Curve should loop from the last point back to the first point (Valid for splines only).
 


### PR DESCRIPTION
This updates MarkupsToModel to not use deprecated Slicer Markups API.

cc: @lassoan for review