### PR TITLE
COMP: Explicitly link against vtkAddon following relocation of classes

### DIFF
--- a/MarkupsToModel/Logic/CMakeLists.txt
+++ b/MarkupsToModel/Logic/CMakeLists.txt
@@ -19,6 +19,7 @@ set(${KIT}_TARGET_LIBRARIES
   vtkSlicer${MODULE_NAME}ModuleMRML
   vtkSlicerMarkupsModuleMRML
   vtkSlicerMarkupsModuleLogic
+  vtkAddon
   )
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
After moving the classes like vtkCurveGenerator from Slicer into vtkAddon, this commit accounts for this to avoid relying on the implicit linking from the MRMLCore target.

References:
* https://github.com/Slicer/Slicer/pull/6883
* https://github.com/Slicer/Slicer/issues/6603