### PR TITLE
COMP: Fix Q_PLUGIN_METADATA usage for Qt6 builds

### DIFF
--- a/MarkupsToModel/qSlicerMarkupsToModelModule.h
+++ b/MarkupsToModel/qSlicerMarkupsToModelModule.h
@@ -21,8 +21,6 @@
 // SlicerQt includes
 #include "qSlicerLoadableModule.h"
 
-#include "vtkSlicerConfigure.h" // For Slicer_HAVE_QT5
-
 #include "qSlicerMarkupsToModelModuleExport.h"
 
 class qSlicerMarkupsToModelModulePrivate;
@@ -33,9 +31,7 @@ qSlicerMarkupsToModelModule
   : public qSlicerLoadableModule
 {
   Q_OBJECT
-#ifdef Slicer_HAVE_QT5
   Q_PLUGIN_METADATA(IID "org.slicer.modules.loadable.qSlicerLoadableModule/1.0");
-#endif
   Q_INTERFACES(qSlicerLoadableModule);
 
 public:


### PR DESCRIPTION
Q_PLUGIN_METADATA has been required since Qt5, and Slicer dropped Qt4 support years ago. The ifdef can be removed. This provides support for Qt6 which needs the same code in the ifdef.

cc: @lassoan 

Similar change made over in https://github.com/IGSIO/SlicerIGSIO/pull/35.